### PR TITLE
update to THREE rev 69

### DIFF
--- a/js/ColladaLoader.js
+++ b/js/ColladaLoader.js
@@ -4797,12 +4797,13 @@ THREE.ColladaLoader = function () {
 
 		}
 
-		return new THREE.Matrix4(
+		//THREE.Matrix4: the constructor no longer reads arguments. use .set() instead.
+		return new THREE.Matrix4().set(
 			data[0], data[1], data[2], data[3],
 			data[4], data[5], data[6], data[7],
 			data[8], data[9], data[10], data[11],
 			data[12], data[13], data[14], data[15]
-			);
+		);
 
 	};
 


### PR DESCRIPTION
//THREE.Matrix4: the constructor no longer reads arguments. use .set() instead.
